### PR TITLE
Add GitHub workflow for testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "**" # matches every branch
+name: "Node.js Lint, Tests and Coverage"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+          cache: "npm"
+      - run: npm i npm@8 -g
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format
+      # TODO: Uncomment this section when we have tests
+      # - uses: docker/login-action@v1
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.repository_owner }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
+      # - run: docker compose up -d # tests need services
+      # - run: npm run test


### PR DESCRIPTION
This is the same workflow from fuels-ts. We have no tests ATM so it only runs `lint` and `format`.

When we have tests, we can uncomment the [commented lines](https://github.com/FuelLabs/block-explorer-v2/pull/21/files#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR22-R29).