### PR TITLE
Format file generated from GQL on build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "format:fix": "prettier --write src",
     "eject": "react-scripts eject",
     "cypress:open": "cypress open",
-    "build-operations": "graphql-codegen",
+    "build-operations": "graphql-codegen && prettier --write src/api/types.ts",
     "update-schema": "get-graphql-schema http://localhost:4000/graphql > schema.graphql",
     "postinstall": "npm run build-operations"
   },


### PR DESCRIPTION
Before this change, the generated `src/api/types.ts` would not be formatted, so you'd have to manually run `npm run format:fix`. Now it's automatically formatted so that e.g. running `npm i` won't result in a git diff.