### PR TITLE
Update jsxBracketSameLine to bracketSameLine in prettier config.

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,5 @@
   "printWidth": 100,
   "singleQuote": false,
   "trailingComma": "all",
-  "jsxBracketSameLine": true
+  "bracketSameLine": false
 }


### PR DESCRIPTION
Was giving the warning

```console
[warn] jsxBracketSameLine is deprecated.
```

Renamed to `bracketSameLine`: https://prettier.io/blog/2021/09/09/2.4.0.html