### PR TITLE
feat: explore contract and script transactions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,13 +8,25 @@ import { TransactionPage } from "./pages/TransactionPage";
 import { BlockTransactionsPage } from "./pages/BlockTransactionsPage";
 import { CreateTransactionPage } from "./pages/CreateTransactionPage";
 import { ContractPage } from "./pages/ContractPage";
-import { config } from "./config";
 import { ChainProvider } from "./contexts/network";
 
+const { REACT_APP_GRAPHQL_API_ENDPOINT } = process.env;
+
 const client = new ApolloClient({
-  uri: config.apiUrl,
-  // link: authLink.concat(httpLink),
+  uri: REACT_APP_GRAPHQL_API_ENDPOINT,
   cache: new InMemoryCache(),
+  // We can configure for each schema the keys to cache, without
+  // this config for each one objects without id, will not work
+  defaultOptions: {
+    watchQuery: {
+      fetchPolicy: 'no-cache',
+      errorPolicy: 'ignore',
+    },
+    query: {
+      fetchPolicy: 'no-cache',
+      errorPolicy: 'all',
+    },
+  }
 });
 
 function App() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,14 +19,14 @@ const client = new ApolloClient({
   // this config for each one objects without id, will not work
   defaultOptions: {
     watchQuery: {
-      fetchPolicy: 'no-cache',
-      errorPolicy: 'ignore',
+      fetchPolicy: "no-cache",
+      errorPolicy: "ignore",
     },
     query: {
-      fetchPolicy: 'no-cache',
-      errorPolicy: 'all',
+      fetchPolicy: "no-cache",
+      errorPolicy: "all",
     },
-  }
+  },
 });
 
 function App() {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,0 @@
-export const config = {
-  apiUrl: process.env.REACT_APP_GRAPHQL_API_ENDPOINT,
-};

--- a/src/pages/HomePage/RecentTransactions.tsx
+++ b/src/pages/HomePage/RecentTransactions.tsx
@@ -56,7 +56,7 @@ const TransactionRow = ({ transaction }: { transaction: HomePageTransaction }) =
         <TransactionHashColumn>
           <TransactionAddress
             id="recent-transaction-link"
-            to={`/${transaction.isScript === false ? "create-transaction" : "transaction"}/${
+            to={`/transaction/${
               transaction.id
             }`}
           >

--- a/src/pages/HomePage/RecentTransactions.tsx
+++ b/src/pages/HomePage/RecentTransactions.tsx
@@ -54,12 +54,7 @@ const TransactionRow = ({ transaction }: { transaction: HomePageTransaction }) =
           <TxType>{transaction.isScript ? "Script" : "Create"}</TxType>
         </TransactionTypeColumn>
         <TransactionHashColumn>
-          <TransactionAddress
-            id="recent-transaction-link"
-            to={`/transaction/${
-              transaction.id
-            }`}
-          >
+          <TransactionAddress id="recent-transaction-link" to={`/transaction/${transaction.id}`}>
             {transaction.id}
           </TransactionAddress>
           <DataTimestamp>{timestamp}</DataTimestamp>

--- a/src/pages/TransactionPage/components.tsx
+++ b/src/pages/TransactionPage/components.tsx
@@ -342,3 +342,34 @@ export const ScriptPlaceholder = styled.div`
   height: 236px;
   background-color: #1e2e2b;
 `;
+
+export const ScriptTextarea = styled.textarea`
+  padding: 24px;
+  height: 200px;
+  width: 100%;
+  background-color: #03261e;
+  border: 0;
+  color: #ffffff;
+  resize: none;
+  font-family: SFProDisplay;
+
+  :focus {
+    border: 0;
+    outline: 0;
+  }
+`;
+
+export const ContractTextarea = styled.textarea`
+  height: 200px;
+  width: 100%;
+  background-color: transparent;
+  border: 0;
+  color: #ffffff;
+  resize: none;
+  font-family: SFProDisplay;
+
+  :focus {
+    border: 0;
+    outline: 0;
+  }
+`;

--- a/src/pages/TransactionPage/index.tsx
+++ b/src/pages/TransactionPage/index.tsx
@@ -32,13 +32,15 @@ import {
   ScriptContainer,
   ScriptTabsContainer,
   ScriptTabButton,
-  ScriptPlaceholder,
+  ScriptTextarea,
   UTXOHeadlineColumn2,
+  ContractTextarea,
 } from "./components";
 import { useParams } from "react-router-dom";
 import { ExpandIcon, ShrinkIcon } from "../../components/Icons";
 import { trimAddress } from "../../utils";
 import { InputFragment, OutputFragment, useTransactionPageQuery } from "./__generated__/operations";
+import { UTXODetailsValue } from "../CreateTransactionPage/components";
 
 export function TransactionPage() {
   const { transaction } = useParams() as any;
@@ -73,7 +75,7 @@ export function TransactionPage() {
             </TransactionDataRow>
             <TransactionDataRow>
               <RowKeyColumn>Gas Price:</RowKeyColumn>
-              <RowValueColumn>{`${tx.gasPrice} gwei`}</RowValueColumn>
+              <RowValueColumn>{tx.gasPrice}</RowValueColumn>
             </TransactionDataRow>
             <TransactionDataRow>
               <RowKeyColumn>Gas Limit:</RowKeyColumn>
@@ -81,30 +83,51 @@ export function TransactionPage() {
             </TransactionDataRow>
             <TransactionDataRow>
               <RowKeyColumn>Gas Used:</RowKeyColumn>
-              <RowValueColumn>TBD</RowValueColumn>
+              <RowValueColumn>0</RowValueColumn>
             </TransactionDataRow>
           </TransactionDataContainer>
           <UTXOComponent outputs={tx.outputs || []} inputs={tx.inputs || []} />
-          <ScriptsComponent />
+          {tx.isScript ? (
+            <ScriptsComponent tx={tx} />
+          ) : (
+            <ContractComponent tx={tx} />
+          )}
         </Content>
       </Container>
     </>
   );
 }
 
-function ScriptsComponent() {
+function ContractComponent({ tx }: { tx: any }) {
+  return (
+    tx.witnesses.map((witness: string, index: number) => (
+      <UTXOBoxContainer>
+        <UTXOHeadlineContainer>
+          <UTXOHeadlineColumn>
+            <UTXOTitle>Witness #{index}</UTXOTitle>
+          </UTXOHeadlineColumn>
+        </UTXOHeadlineContainer>
+        <UTXODetailsContainer>
+          <ContractTextarea readOnly={true} value={witness} />
+        </UTXODetailsContainer>
+      </UTXOBoxContainer>
+    ))
+  )
+}
+
+function ScriptsComponent({ tx }: { tx: any }) {
   return (
     <ScriptsContainer>
       <ScriptTitle>Script Byte Code:</ScriptTitle>
-      <ScriptComponent tabs={["Assembly", "Hex"]} />
+      <ScriptComponent tabs={["Assembly", "Hex"]} contents={['', tx.script]} />
       <ScriptTitle>Script Data:</ScriptTitle>
-      <ScriptComponent tabs={["ABI Decoded", "Raw Hex"]} />
+      <ScriptComponent tabs={["ABI Decoded", "Raw Hex"]} contents={['', tx.scriptData]} />
     </ScriptsContainer>
   );
 }
 
-function ScriptComponent({ tabs }: { tabs: string[] }) {
-  const [selectedTab, setSelectedTab] = useState(0);
+function ScriptComponent({ tabs, contents }: { tabs: string[], contents: string[] }) {
+  const [selectedTab, setSelectedTab] = useState(1);
 
   return (
     <ScriptContainer>
@@ -121,7 +144,7 @@ function ScriptComponent({ tabs }: { tabs: string[] }) {
           </ScriptTabButton>
         ))}
       </ScriptTabsContainer>
-      <ScriptPlaceholder />
+      <ScriptTextarea readOnly={true} value={contents[selectedTab]} />
     </ScriptContainer>
   );
 }
@@ -160,7 +183,7 @@ function UTXOComponent({
         </UTXOSeparatorColumn>
         <UTXOBoxesColumn>
           {outputs.map((output, idx) => (
-            <UTXOOutputBox key={idx} output={output} expanded={expanded} />
+            <UTXOOutputBox key={idx} index={idx} output={output} expanded={expanded} />
           ))}
         </UTXOBoxesColumn>
       </UTXOBoxesContainer>
@@ -177,102 +200,169 @@ function UTXOInputBox({
   expanded: boolean;
   idx: number;
 }) {
-  if (input.__typename === "InputCoin") {
-    return (
-      <UTXOBoxContainer>
-        <UTXOHeadlineContainer>
-          <UTXOHeadlineColumn>
-            <UTXOTitle>{`Input #${idx + 1}`}</UTXOTitle>
-            <UTXOHash to={`/transaction/${input.utxoId}`}>{input.utxoId}</UTXOHash>
-          </UTXOHeadlineColumn>
-          <UTXOHeadlineColumn2>
-            <HeadlineText>TBD</HeadlineText>
-            <HeadlineText>{input.amount}</HeadlineText>
-          </UTXOHeadlineColumn2>
-        </UTXOHeadlineContainer>
-        {expanded && (
-          <UTXODetailsContainer>
-            <UTXODetailsRow>
-              <UTXODetailsKey>Owner:</UTXODetailsKey>
-              <UTXODetailsLink to={`/address/${input.utxoId}`}>
-                {trimAddress(input.owner)}
-              </UTXODetailsLink>
-            </UTXODetailsRow>
-            <UTXODetailsRow>
-              <UTXODetailsKey>Amount:</UTXODetailsKey>
-              {input.amount}
-            </UTXODetailsRow>
-            <UTXODetailsRow>
-              <UTXODetailsKey>Coin:</UTXODetailsKey>
-              <UTXODetailsLink to={`/coin/${input.assetId}`}>
-                {trimAddress(input.assetId)}
-              </UTXODetailsLink>
-            </UTXODetailsRow>
-            <UTXODetailsRow>
-              <UTXODetailsKey>Predicate bytecode:</UTXODetailsKey>
-              {input.predicate}
-            </UTXODetailsRow>
-            <UTXODetailsRow>
-              <UTXODetailsKey>Predicate data:</UTXODetailsKey>
-              {input.predicateData}
-            </UTXODetailsRow>
-            <UTXODetailsRow>
-              <UTXODetailsKey>Predicate length:</UTXODetailsKey>
-              TBD
-            </UTXODetailsRow>
-          </UTXODetailsContainer>
-        )}
-      </UTXOBoxContainer>
-    );
+  switch (input.__typename) {
+    case "InputCoin": {
+      return (
+        <UTXOBoxContainer>
+          <UTXOHeadlineContainer>
+            <UTXOHeadlineColumn>
+              <UTXOTitle>{`Input #${idx}`}</UTXOTitle>
+              <UTXOHash to={`/transaction/${input.utxoId}`}>{input.utxoId}</UTXOHash>
+            </UTXOHeadlineColumn>
+            <UTXOHeadlineColumn2>
+              <HeadlineText>Value</HeadlineText>
+              <HeadlineText>{input.amount}</HeadlineText>
+            </UTXOHeadlineColumn2>
+          </UTXOHeadlineContainer>
+          {expanded && (
+            <UTXODetailsContainer>
+              <UTXODetailsRow>
+                <UTXODetailsKey>Owner:</UTXODetailsKey>
+                <UTXODetailsLink to={`/address/${input.utxoId}`}>
+                  {trimAddress(input.owner)}
+                </UTXODetailsLink>
+              </UTXODetailsRow>
+              <UTXODetailsRow>
+                <UTXODetailsKey>Amount:</UTXODetailsKey>
+                {input.amount}
+              </UTXODetailsRow>
+              <UTXODetailsRow>
+                <UTXODetailsKey>Coin:</UTXODetailsKey>
+                <UTXODetailsLink to={`/coin/${input.assetId}`}>
+                  {trimAddress(input.assetId)}
+                </UTXODetailsLink>
+              </UTXODetailsRow>
+              <UTXODetailsRow>
+                <UTXODetailsKey>Predicate bytecode:</UTXODetailsKey>
+                {input.predicate}
+              </UTXODetailsRow>
+              <UTXODetailsRow>
+                <UTXODetailsKey>Predicate data:</UTXODetailsKey>
+                {input.predicateData}
+              </UTXODetailsRow>
+              <UTXODetailsRow>
+                <UTXODetailsKey>Predicate length:</UTXODetailsKey>
+                {0}
+                {/* {TBD} */}
+              </UTXODetailsRow>
+              <UTXODetailsRow>
+                <UTXODetailsKey>Witness Index:</UTXODetailsKey>
+                {input.witnessIndex}
+              </UTXODetailsRow>
+            </UTXODetailsContainer>
+          )}
+        </UTXOBoxContainer>
+      )
+    }
+    case "InputContract": {
+      return (
+        <UTXOBoxContainer>
+          <UTXOHeadlineContainer>
+            <UTXOHeadlineColumn>
+              <UTXOTitle>{`Input #${idx}`}</UTXOTitle>
+              <UTXOHash to={`/transaction/${input.utxoId}`}>{input.utxoId}</UTXOHash>
+            </UTXOHeadlineColumn>
+          </UTXOHeadlineContainer>
+          {expanded && (
+            <UTXODetailsContainer>
+              <UTXODetailsRow>
+                <UTXODetailsKey>Contract Id:</UTXODetailsKey>
+                <UTXODetailsLink to={`/contract/${input.contract.id}`}>{trimAddress(input.contract.id)}</UTXODetailsLink>
+              </UTXODetailsRow>
+              <UTXODetailsRow>
+                <UTXODetailsKey>Balance Root:</UTXODetailsKey>
+                <UTXODetailsValue>
+                  {trimAddress(input.balanceRoot)}
+                </UTXODetailsValue>
+              </UTXODetailsRow>
+              <UTXODetailsRow>
+                <UTXODetailsKey>State Root:</UTXODetailsKey>
+                <UTXODetailsValue>
+                  {trimAddress(input.stateRoot)}
+                </UTXODetailsValue>
+              </UTXODetailsRow>
+            </UTXODetailsContainer>
+          )}
+        </UTXOBoxContainer>
+      )
+    }
+    default: return null;
   }
-  return <>{input.__typename}</>;
 }
 
-function UTXOOutputBox({ output, expanded }: { output: OutputFragment; expanded: boolean }) {
+function UTXOOutput ({ output }: { output: OutputFragment }) {
+  switch (output.__typename) {
+    case "ContractCreated": {
+      return (
+        <UTXODetailsRow>
+          <UTXODetailsKey>Contract Id:</UTXODetailsKey>
+          <UTXODetailsLink to={`/contract/${output.contract.id}`}>{output.contract.id}</UTXODetailsLink>
+        </UTXODetailsRow>
+      )
+    }
+    case "ContractOutput": {
+      return (
+        <>
+        <UTXODetailsRow>
+          <UTXODetailsKey>Balance Root:</UTXODetailsKey>
+          <UTXODetailsValue>{trimAddress(output.balanceRoot)}</UTXODetailsValue>
+        </UTXODetailsRow>
+        <UTXODetailsRow>
+          <UTXODetailsKey>State Root:</UTXODetailsKey>
+          <UTXODetailsValue>{trimAddress(output.stateRoot)}</UTXODetailsValue>
+        </UTXODetailsRow>
+        <UTXODetailsRow>
+          <UTXODetailsKey>Input index:</UTXODetailsKey>
+          <UTXODetailsValue>{output.inputIndex}</UTXODetailsValue>
+        </UTXODetailsRow>
+      </>
+      )
+    }
+    case "CoinOutput":
+    case "ChangeOutput": {
+      return (
+        <>
+          <UTXODetailsRow>
+            <UTXODetailsKey>To:</UTXODetailsKey>
+            <UTXODetailsLink to={`/address/${output.to}`}>
+              {trimAddress(output.to)}
+            </UTXODetailsLink>
+          </UTXODetailsRow>
+          <UTXODetailsRow>
+            <UTXODetailsKey>Amount:</UTXODetailsKey>
+            <UTXODetailsValue>{output.amount}</UTXODetailsValue>
+          </UTXODetailsRow>
+          <UTXODetailsRow>
+            <UTXODetailsKey>Coin:</UTXODetailsKey>
+            <UTXODetailsLink to={`/coin/${output.assetId}`}>
+              {trimAddress(output.assetId)}
+            </UTXODetailsLink>
+          </UTXODetailsRow>
+        </>
+      )
+    }
+    default: return null;
+  }
+}
+
+function UTXOOutputBox({ output, expanded, index }: { output: OutputFragment; expanded: boolean, index: number }) {
   return (
     <UTXOBoxContainer>
       <UTXOHeadlineContainer>
         <UTXOHeadlineColumn>
-          <UTXOTitle>Output</UTXOTitle>
-          <UTXOHash to={`/`}>TBD</UTXOHash>
+          <UTXOTitle>Output #{index}</UTXOTitle>
+          <UTXOHash to={`/`}>{output.__typename}</UTXOHash>
         </UTXOHeadlineColumn>
         {output.__typename === "CoinOutput" && (
           <UTXOHeadlineColumn2>
-            <HeadlineText>TBD</HeadlineText>
+            <HeadlineText>Amount</HeadlineText>
             <HeadlineText>{output.amount}</HeadlineText>
           </UTXOHeadlineColumn2>
         )}
       </UTXOHeadlineContainer>
       {expanded && (
         <UTXODetailsContainer>
-          <UTXODetailsRow>
-            <UTXODetailsKey>To:</UTXODetailsKey>
-            {(() => {
-              if (output.__typename === "CoinOutput") {
-                return (
-                  <UTXODetailsLink to={`/address/${output.to}`}>
-                    {trimAddress(output.to)}
-                  </UTXODetailsLink>
-                );
-              }
-            })()}
-          </UTXODetailsRow>
-          <UTXODetailsRow>
-            <UTXODetailsKey>Amount:</UTXODetailsKey>
-            {(() => {
-              if (output.__typename === "CoinOutput") {
-                return output.amount;
-              }
-            })()}
-          </UTXODetailsRow>
-          {/* <UTXODetailsRow>
-            <UTXODetailsKey>Coin:</UTXODetailsKey>
-            <UTXODetailsLink to={`/coin/${data.symbol}`}>{data.symbol}</UTXODetailsLink>
-          </UTXODetailsRow> */}
-          {/* <UTXODetailsRow>
-            <UTXODetailsKey>Spent:</UTXODetailsKey>
-            {data.spent}
-          </UTXODetailsRow> */}
+          <UTXOOutput output={output} />
         </UTXODetailsContainer>
       )}
     </UTXOBoxContainer>

--- a/src/pages/TransactionPage/index.tsx
+++ b/src/pages/TransactionPage/index.tsx
@@ -87,11 +87,7 @@ export function TransactionPage() {
             </TransactionDataRow>
           </TransactionDataContainer>
           <UTXOComponent outputs={tx.outputs || []} inputs={tx.inputs || []} />
-          {tx.isScript ? (
-            <ScriptsComponent tx={tx} />
-          ) : (
-            <ContractComponent tx={tx} />
-          )}
+          {tx.isScript ? <ScriptsComponent tx={tx} /> : <ContractComponent tx={tx} />}
         </Content>
       </Container>
     </>
@@ -99,34 +95,32 @@ export function TransactionPage() {
 }
 
 function ContractComponent({ tx }: { tx: any }) {
-  return (
-    tx.witnesses.map((witness: string, index: number) => (
-      <UTXOBoxContainer>
-        <UTXOHeadlineContainer>
-          <UTXOHeadlineColumn>
-            <UTXOTitle>Witness #{index}</UTXOTitle>
-          </UTXOHeadlineColumn>
-        </UTXOHeadlineContainer>
-        <UTXODetailsContainer>
-          <ContractTextarea readOnly={true} value={witness} />
-        </UTXODetailsContainer>
-      </UTXOBoxContainer>
-    ))
-  )
+  return tx.witnesses.map((witness: string, index: number) => (
+    <UTXOBoxContainer>
+      <UTXOHeadlineContainer>
+        <UTXOHeadlineColumn>
+          <UTXOTitle>Witness #{index}</UTXOTitle>
+        </UTXOHeadlineColumn>
+      </UTXOHeadlineContainer>
+      <UTXODetailsContainer>
+        <ContractTextarea readOnly={true} value={witness} />
+      </UTXODetailsContainer>
+    </UTXOBoxContainer>
+  ));
 }
 
 function ScriptsComponent({ tx }: { tx: any }) {
   return (
     <ScriptsContainer>
       <ScriptTitle>Script Byte Code:</ScriptTitle>
-      <ScriptComponent tabs={["Assembly", "Hex"]} contents={['', tx.script]} />
+      <ScriptComponent tabs={["Assembly", "Hex"]} contents={["", tx.script]} />
       <ScriptTitle>Script Data:</ScriptTitle>
-      <ScriptComponent tabs={["ABI Decoded", "Raw Hex"]} contents={['', tx.scriptData]} />
+      <ScriptComponent tabs={["ABI Decoded", "Raw Hex"]} contents={["", tx.scriptData]} />
     </ScriptsContainer>
   );
 }
 
-function ScriptComponent({ tabs, contents }: { tabs: string[], contents: string[] }) {
+function ScriptComponent({ tabs, contents }: { tabs: string[]; contents: string[] }) {
   const [selectedTab, setSelectedTab] = useState(1);
 
   return (
@@ -252,7 +246,7 @@ function UTXOInputBox({
             </UTXODetailsContainer>
           )}
         </UTXOBoxContainer>
-      )
+      );
     }
     case "InputContract": {
       return (
@@ -267,56 +261,57 @@ function UTXOInputBox({
             <UTXODetailsContainer>
               <UTXODetailsRow>
                 <UTXODetailsKey>Contract Id:</UTXODetailsKey>
-                <UTXODetailsLink to={`/contract/${input.contract.id}`}>{trimAddress(input.contract.id)}</UTXODetailsLink>
+                <UTXODetailsLink to={`/contract/${input.contract.id}`}>
+                  {trimAddress(input.contract.id)}
+                </UTXODetailsLink>
               </UTXODetailsRow>
               <UTXODetailsRow>
                 <UTXODetailsKey>Balance Root:</UTXODetailsKey>
-                <UTXODetailsValue>
-                  {trimAddress(input.balanceRoot)}
-                </UTXODetailsValue>
+                <UTXODetailsValue>{trimAddress(input.balanceRoot)}</UTXODetailsValue>
               </UTXODetailsRow>
               <UTXODetailsRow>
                 <UTXODetailsKey>State Root:</UTXODetailsKey>
-                <UTXODetailsValue>
-                  {trimAddress(input.stateRoot)}
-                </UTXODetailsValue>
+                <UTXODetailsValue>{trimAddress(input.stateRoot)}</UTXODetailsValue>
               </UTXODetailsRow>
             </UTXODetailsContainer>
           )}
         </UTXOBoxContainer>
-      )
+      );
     }
-    default: return null;
+    default:
+      return null;
   }
 }
 
-function UTXOOutput ({ output }: { output: OutputFragment }) {
+function UTXOOutput({ output }: { output: OutputFragment }) {
   switch (output.__typename) {
     case "ContractCreated": {
       return (
         <UTXODetailsRow>
           <UTXODetailsKey>Contract Id:</UTXODetailsKey>
-          <UTXODetailsLink to={`/contract/${output.contract.id}`}>{output.contract.id}</UTXODetailsLink>
+          <UTXODetailsLink to={`/contract/${output.contract.id}`}>
+            {output.contract.id}
+          </UTXODetailsLink>
         </UTXODetailsRow>
-      )
+      );
     }
     case "ContractOutput": {
       return (
         <>
-        <UTXODetailsRow>
-          <UTXODetailsKey>Balance Root:</UTXODetailsKey>
-          <UTXODetailsValue>{trimAddress(output.balanceRoot)}</UTXODetailsValue>
-        </UTXODetailsRow>
-        <UTXODetailsRow>
-          <UTXODetailsKey>State Root:</UTXODetailsKey>
-          <UTXODetailsValue>{trimAddress(output.stateRoot)}</UTXODetailsValue>
-        </UTXODetailsRow>
-        <UTXODetailsRow>
-          <UTXODetailsKey>Input index:</UTXODetailsKey>
-          <UTXODetailsValue>{output.inputIndex}</UTXODetailsValue>
-        </UTXODetailsRow>
-      </>
-      )
+          <UTXODetailsRow>
+            <UTXODetailsKey>Balance Root:</UTXODetailsKey>
+            <UTXODetailsValue>{trimAddress(output.balanceRoot)}</UTXODetailsValue>
+          </UTXODetailsRow>
+          <UTXODetailsRow>
+            <UTXODetailsKey>State Root:</UTXODetailsKey>
+            <UTXODetailsValue>{trimAddress(output.stateRoot)}</UTXODetailsValue>
+          </UTXODetailsRow>
+          <UTXODetailsRow>
+            <UTXODetailsKey>Input index:</UTXODetailsKey>
+            <UTXODetailsValue>{output.inputIndex}</UTXODetailsValue>
+          </UTXODetailsRow>
+        </>
+      );
     }
     case "CoinOutput":
     case "ChangeOutput": {
@@ -324,9 +319,7 @@ function UTXOOutput ({ output }: { output: OutputFragment }) {
         <>
           <UTXODetailsRow>
             <UTXODetailsKey>To:</UTXODetailsKey>
-            <UTXODetailsLink to={`/address/${output.to}`}>
-              {trimAddress(output.to)}
-            </UTXODetailsLink>
+            <UTXODetailsLink to={`/address/${output.to}`}>{trimAddress(output.to)}</UTXODetailsLink>
           </UTXODetailsRow>
           <UTXODetailsRow>
             <UTXODetailsKey>Amount:</UTXODetailsKey>
@@ -339,13 +332,22 @@ function UTXOOutput ({ output }: { output: OutputFragment }) {
             </UTXODetailsLink>
           </UTXODetailsRow>
         </>
-      )
+      );
     }
-    default: return null;
+    default:
+      return null;
   }
 }
 
-function UTXOOutputBox({ output, expanded, index }: { output: OutputFragment; expanded: boolean, index: number }) {
+function UTXOOutputBox({
+  output,
+  expanded,
+  index,
+}: {
+  output: OutputFragment;
+  expanded: boolean;
+  index: number;
+}) {
   return (
     <UTXOBoxContainer>
       <UTXOHeadlineContainer>

--- a/src/pages/TransactionPage/operations.graphql
+++ b/src/pages/TransactionPage/operations.graphql
@@ -3,6 +3,11 @@ query TransactionPageQuery($id: TransactionId!) {
     id
     inputContracts {
       id
+      bytecode
+    }
+    staticContracts {
+      id
+      bytecode
     }
     inputAssetIds
     gasPrice
@@ -10,7 +15,10 @@ query TransactionPageQuery($id: TransactionId!) {
     maturity
     isScript
     receiptsRoot
+    script
+    scriptData
     witnesses
+    bytecodeWitnessIndex
     outputs {
       ...OutputFragment
     }


### PR DESCRIPTION
### Summary

- Add explore `script` and `contract`
- Simplify the `create-transaction` route to be the same `transaction`
- Add show witness raw binary on `contract/script` transactions

### Preview
<img width="1214" alt="Screen Shot 2022-03-21 at 11 36 37 PM" src="https://user-images.githubusercontent.com/3941923/159396745-35d6e50f-b853-40df-8b30-c4d385f3243b.png">
<img width="1234" alt="Screen Shot 2022-03-21 at 11 36 55 PM" src="https://user-images.githubusercontent.com/3941923/159396759-4c324de0-b5c7-425a-8f97-35389c786986.png">
<img width="1304" alt="Screen Shot 2022-03-21 at 11 37 15 PM" src="https://user-images.githubusercontent.com/3941923/159396763-a36b512b-edc3-4412-8610-d0fd47abb3c7.png">
<img width="1235" alt="Screen Shot 2022-03-21 at 11 37 43 PM" src="https://user-images.githubusercontent.com/3941923/159396777-1a2a61e9-4a27-429c-8351-c5292ab6f23e.png">

