### PR TITLE
fix: homepage config overrides PUBLIC_URL breaking deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "engines": {
     "npm": ">=8.0.0"
   },
-  "homepage": "./",
   "scripts": {
     "start": "craco start",
     "build": "craco build",


### PR DESCRIPTION
The configuration of the homepage on package.json will override the PUBLIC_URL environment variable, breaking the production build. Also removing it will not affect development.

```
homepage: './'
```