### PR TITLE
44 add option to configure other node address like localhost directly on the deployed version

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,18 @@ import { ChainProvider } from "./contexts/network";
 
 const { REACT_APP_GRAPHQL_API_ENDPOINT, PUBLIC_URL } = process.env;
 
+let parsedLocalStorageGraphQLEndpoint = null;
+try {
+  // Get from local storage by key
+  const item = localStorage.getItem("GRAPHQL_API_ENDPOINT");
+  // Parse stored json or if none return initialValue
+  parsedLocalStorageGraphQLEndpoint = item ? JSON.parse(item) : null;
+} catch (error) {
+  console.debug(error);
+}
+
 const client = new ApolloClient({
-  uri: REACT_APP_GRAPHQL_API_ENDPOINT,
+  uri: parsedLocalStorageGraphQLEndpoint || REACT_APP_GRAPHQL_API_ENDPOINT,
   cache: new InMemoryCache(),
   // We can configure for each schema the keys to cache, without
   // this config for each one objects without id, will not work

--- a/src/components/Modals/NetworkModal/components.tsx
+++ b/src/components/Modals/NetworkModal/components.tsx
@@ -20,6 +20,41 @@ export const Title = styled.h2`
   color: #f8fefc;
 `;
 
+export const SubTitle = styled.h3`
+  margin: 20px 0;
+  font-family: SFProDisplay;
+  font-size: 14px;
+  font-weight: 500;
+  text-align: center;
+  color: #f8fefc;
+  cursor: pointer;
+`;
+
+export const CustomInputContainer = styled.div<{ show: boolean }>`
+  margin: 22px 40px 22px 32px;
+  display: ${({ show }) => (show ? "flex" : "none")};
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const CustomInputField = styled.input`
+  flex-grow: 1;
+  margin-right: 8px;
+`;
+
+export const CustomInputReset = styled(ButtonReset)`
+  background-color: #58c09b;
+  font-family: SFProDisplay;
+  padding: 2px 4px;
+  font-weight: 500;
+  color: #fff;
+
+  :hover,
+  :active {
+    box-shadow: 0 0 6px 0 #58c09b;
+  }
+`;
+
 export const NetworkSelectorCheckbox = styled.div`
   width: 24px;
   height: 24px;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export function useOnClickOutside(ref: any, handler: () => void) {
   useEffect(() => {
@@ -18,4 +18,42 @@ export function useOnClickOutside(ref: any, handler: () => void) {
       document.removeEventListener('touchstart', listener);
     };
   }, [ref, handler]);
+}
+
+// Hook
+export function useLocalStorage<T>(key: string, initialValue?: T): [T, (update: T) => void] {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return initialValue;
+    }
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key);
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      return initialValue;
+    }
+  });
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value: T) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore = value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      }
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log(error);
+    }
+  };
+  return [storedValue, setValue];
 }


### PR DESCRIPTION
<a href="https://www.loom.com/share/2924bfd12ff94d778634e7c23ed4cb88">
    <p>Fuel explorer - 28 March 2022 - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/2924bfd12ff94d778634e7c23ed4cb88-with-play.gif">
  </a>

## Notes

Wanted to get this out fast, so it uses local storage and just refreshes the window to set it on the apollo client.  I think we should refactor this.

There is no validation and no error handling at the moment.

Need to add tests

User can reset to the base URL from the ENV