### PR TITLE
fix: set with to percent on headline

### DIFF
--- a/src/pages/TransactionPage/components.tsx
+++ b/src/pages/TransactionPage/components.tsx
@@ -199,14 +199,14 @@ export const UTXOHeadlineContainer = styled.div`
 `;
 
 export const UTXOHeadlineColumn = styled.div`
-  width: calc(100% - 100px);
+  width: 50%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 `;
 
 export const UTXOHeadlineColumn2 = styled.div`
-  width: 100px;
+  width: 50%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -228,8 +228,12 @@ export const UTXOHash = styled(BaseLink)`
   white-space: nowrap;
 `;
 
-export const HeadlineText = styled.span`
+export const HeadlineText = styled.p`
+  margin: 0;
   display: block;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 `;
 
 export const UTXODetailsContainer = styled.div`
@@ -257,6 +261,9 @@ export const UTXODetailsRow = styled.div`
 export const UTXODetailsKey = styled.span`
   display: block;
   width: 170px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 `;
 
 export const UTXODetailsLink = styled(Link)`


### PR DESCRIPTION
## TLDR

The values and address were overflowing - this allows them to be flexible in width

<img width="722" alt="Screen Shot 2022-04-15 at 6 53 28 PM" src="https://user-images.githubusercontent.com/2522945/163655467-5a514fe2-1ca7-48d0-88f7-f568ebc8ade3.png">

See https://github.com/FuelLabs/block-explorer-v2/issues/56 for the overflow


## Video

<a href="https://www.loom.com/share/329047f458984160955ec01eb7bd60bd">
    <p>Fuel explorer - 15 April 2022 - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/329047f458984160955ec01eb7bd60bd-with-play.gif">
  </a>




