### PR TITLE
Format BigNumbers with thousand and decimal separators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/units": "^5.6.0",
         "@graphql-codegen/cli": "^2.6.2",
         "@graphql-codegen/near-operation-file-preset": "^2.2.6",
         "@graphql-codegen/typescript": "^2.4.5",
@@ -2937,6 +2938,27 @@
         "@ethersproject/properties": "^5.6.0",
         "@ethersproject/rlp": "^5.6.0",
         "@ethersproject/signing-key": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/units": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.0.tgz",
+      "integrity": "sha512-tig9x0Qmh8qbo1w8/6tmtyrm/QQRviBh389EQ+d8fP4wDsBrJBf08oZfoiz1/uenKK9M78yAP4PoR7SsVoTjsw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0"
       }
     },
     "node_modules/@ethersproject/web": {
@@ -30697,6 +30719,17 @@
         "@ethersproject/properties": "^5.6.0",
         "@ethersproject/rlp": "^5.6.0",
         "@ethersproject/signing-key": "^5.6.0"
+      }
+    },
+    "@ethersproject/units": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.0.tgz",
+      "integrity": "sha512-tig9x0Qmh8qbo1w8/6tmtyrm/QQRviBh389EQ+d8fP4wDsBrJBf08oZfoiz1/uenKK9M78yAP4PoR7SsVoTjsw==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0"
       }
     },
     "@ethersproject/web": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@ethersproject/bytes": "^5.6.0",
+    "@ethersproject/units": "^5.6.0",
     "@graphql-codegen/cli": "^2.6.2",
     "@graphql-codegen/near-operation-file-preset": "^2.2.6",
     "@graphql-codegen/typescript": "^2.4.5",

--- a/src/pages/TransactionPage/index.tsx
+++ b/src/pages/TransactionPage/index.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 import { Header } from '../../components/Header';
 import { ExpandIcon, ShrinkIcon } from '../../components/Icons';
 import { trimAddress } from '../../utils';
+import { parseToFormattedNumber } from '../../utils/bigNumber';
 import { UTXODetailsValue } from '../CreateTransactionPage/components';
 
 import type { InputFragment, OutputFragment } from './__generated__/operations';
@@ -82,7 +83,7 @@ export default function TransactionPage() {
             </TransactionDataRow>
             <TransactionDataRow>
               <RowKeyColumn>Gas Limit:</RowKeyColumn>
-              <RowValueColumn>{tx.gasLimit}</RowValueColumn>
+              <RowValueColumn>{parseToFormattedNumber(tx.gasLimit)}</RowValueColumn>
             </TransactionDataRow>
             <TransactionDataRow>
               <RowKeyColumn>Gas Used:</RowKeyColumn>
@@ -208,7 +209,7 @@ function UTXOInputBox({
             </UTXOHeadlineColumn>
             <UTXOHeadlineColumn2>
               <HeadlineText>Value</HeadlineText>
-              <HeadlineText>{input.amount}</HeadlineText>
+              <HeadlineText>{parseToFormattedNumber(input.amount)}</HeadlineText>
             </UTXOHeadlineColumn2>
           </UTXOHeadlineContainer>
           {expanded && (
@@ -361,7 +362,7 @@ function UTXOOutputBox({
         {output.__typename === 'CoinOutput' && (
           <UTXOHeadlineColumn2>
             <HeadlineText>Amount</HeadlineText>
-            <HeadlineText>{output.amount}</HeadlineText>
+            <HeadlineText>{parseToFormattedNumber(output.amount)}</HeadlineText>
           </UTXOHeadlineColumn2>
         )}
       </UTXOHeadlineContainer>

--- a/src/utils/bigNumber.ts
+++ b/src/utils/bigNumber.ts
@@ -1,0 +1,9 @@
+import type { BigNumberish } from '@ethersproject/bignumber';
+import { commify, formatUnits, parseUnits } from '@ethersproject/units';
+
+export const parseToFormattedNumber = (value: string | BigNumberish, unit?: BigNumberish) => {
+  const bigNumber = typeof(value) === "string" ? parseUnits(value, unit) : value;
+ 
+  return commify(formatUnits(bigNumber, unit));
+}
+  

--- a/src/utils/bigNumber.ts
+++ b/src/utils/bigNumber.ts
@@ -1,8 +1,8 @@
 import type { BigNumberish } from '@ethersproject/bignumber';
 import { commify, formatUnits, parseUnits } from '@ethersproject/units';
 
-export const parseToFormattedNumber = (value: string | BigNumberish, unit?: BigNumberish) => {
-  const bigNumber = typeof value === 'string' ? parseUnits(value, unit) : value;
+export const parseToFormattedNumber = (value: string | BigNumberish, unit: BigNumberish = 'kwei') => {
+  const bigNumber = typeof value === 'string' ? parseUnits(value, 0) : value;
 
   return commify(formatUnits(bigNumber, unit));
 };

--- a/src/utils/bigNumber.ts
+++ b/src/utils/bigNumber.ts
@@ -1,7 +1,10 @@
 import type { BigNumberish } from '@ethersproject/bignumber';
 import { commify, formatUnits, parseUnits } from '@ethersproject/units';
 
-export const parseToFormattedNumber = (value: string | BigNumberish, unit: BigNumberish = 'kwei') => {
+export const parseToFormattedNumber = (
+  value: string | BigNumberish,
+  unit: BigNumberish = 'kwei'
+) => {
   const bigNumber = typeof value === 'string' ? parseUnits(value, 0) : value;
 
   return commify(formatUnits(bigNumber, unit));

--- a/src/utils/bigNumber.ts
+++ b/src/utils/bigNumber.ts
@@ -2,8 +2,7 @@ import type { BigNumberish } from '@ethersproject/bignumber';
 import { commify, formatUnits, parseUnits } from '@ethersproject/units';
 
 export const parseToFormattedNumber = (value: string | BigNumberish, unit?: BigNumberish) => {
-  const bigNumber = typeof(value) === "string" ? parseUnits(value, unit) : value;
- 
+  const bigNumber = typeof value === 'string' ? parseUnits(value, unit) : value;
+
   return commify(formatUnits(bigNumber, unit));
-}
-  
+};

--- a/src/utils/bigNumber.ts
+++ b/src/utils/bigNumber.ts
@@ -1,7 +1,8 @@
 import type { BigNumberish } from '@ethersproject/bignumber';
 import { commify, formatUnits, parseUnits } from '@ethersproject/units';
 
+export const DECIMAL_UNITS = 3;
 export const parseToFormattedNumber = (
   value: string | BigNumberish,
-  unit: BigNumberish = 3
+  unit: BigNumberish = DECIMAL_UNITS
 ) => commify(formatUnits(value, unit));

--- a/src/utils/bigNumber.ts
+++ b/src/utils/bigNumber.ts
@@ -3,9 +3,5 @@ import { commify, formatUnits, parseUnits } from '@ethersproject/units';
 
 export const parseToFormattedNumber = (
   value: string | BigNumberish,
-  unit: BigNumberish = 'kwei'
-) => {
-  const bigNumber = typeof value === 'string' ? parseUnits(value, 0) : value;
-
-  return commify(formatUnits(bigNumber, unit));
-};
+  unit: BigNumberish = 3
+) => commify(formatUnits(value, unit));


### PR DESCRIPTION
This PR introduces a way to format BigNumbers as "regular" numbers, with thousand and decimal separators.
It uses some functions from `ethers` project to handle the conversion

Closes #39

![image](https://user-images.githubusercontent.com/8636507/167769842-a4254b39-0ebc-4e09-a951-6ab946a4b68e.png)
