### PR TITLE
Add copy button to cut addresses

### DIFF
--- a/src/pages/AddressPage/TransactionsTable.tsx
+++ b/src/pages/AddressPage/TransactionsTable.tsx
@@ -2,6 +2,7 @@
 import * as TableUI from '../../components/Table/components';
 import { parseToFormattedNumber } from '../../utils/bigNumber';
 import { dateDiffRelative, getTextForRelativeTimeDifference } from '../../utils/date';
+import { UTXOHashOutputSkip } from '../TransactionPage/components';
 
 import type { AddressPageTransaction } from './__generated__/operations';
 import {
@@ -12,6 +13,12 @@ import {
   TransactionValue,
   CoinLink,
   CoinLinkSkip,
+  CopyButtonIcon,
+  Tooltip,
+  HeadlineAddressButton,
+  TransactionFromAddressWrapper,
+  TableHeadlineAddressButton,
+  ContractLinkSkip,
   // TableNavigationButtons,
   // TableNavigationNumberButton,
   // TableNavigationTextButton,
@@ -31,6 +38,10 @@ export default function TransactionsTable({
 
     return `${address.slice(0, 6)}...${address.slice(-6, address.length - 1)}`;
   }
+
+  const onClickCopy = (address: string) => {
+    navigator.clipboard.writeText(address);
+  };
 
   return (
     <TableUI.TableContainer>
@@ -79,16 +90,26 @@ export default function TransactionsTable({
                     switch (input.__typename) {
                       case 'InputCoin': {
                         return (
-                          <TxRecipient key={idx} to={`/address/${input.owner}`}>
-                            {trimAddress(input.owner)}
-                          </TxRecipient>
+                          <TransactionFromAddressWrapper key={idx}>
+                            <TxRecipient  to={`/address/${input.owner}`}>
+                              {trimAddress(input.owner)}
+                            </TxRecipient>
+                            <TableHeadlineAddressButton
+                              onClick={() => {
+                                onClickCopy(input.owner);
+                              }}
+                            >
+                              <CopyButtonIcon />
+                              <Tooltip>Copy Address</Tooltip>
+                            </TableHeadlineAddressButton>
+                          </TransactionFromAddressWrapper>
                         );
                       }
                       case 'InputContract': {
                         return (
-                          <TxRecipient key={idx} to={`/address/${input.contract.id}`}>
+                          <ContractLinkSkip key={idx} to="">
                             {trimAddress(input.contract.id)}
-                          </TxRecipient>
+                          </ContractLinkSkip>
                         );
                       }
                       default: {

--- a/src/pages/AddressPage/components.tsx
+++ b/src/pages/AddressPage/components.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { ButtonReset } from '../../components/Button/components';
 import { CopyIcon, PlusIcon, QRIcon, ArrowIcon } from '../../components/Icons';
+import { UTXOHashOutputSkip } from '../TransactionPage/components';
 
 export const Container = styled.section``;
 
@@ -119,6 +120,10 @@ export const HeadlineAddressButton = styled(ButtonReset)`
     display: block;
   }
 `;
+
+export const TableHeadlineAddressButton = styled(HeadlineAddressButton)`
+  margin: -4px 0 0 8px;
+`
 
 export const CopyButtonIcon = styled(CopyIcon)`
   width: 14px !important;
@@ -526,3 +531,13 @@ export const TableNextNavigationTextButton = styled(TableNavigationTextButton)`
     display: none;
   }
 `;
+
+export const TransactionFromAddressWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 10px;
+`;
+
+export const ContractLinkSkip = styled(UTXOHashOutputSkip)`
+  margin-bottom: 8px;
+`

--- a/src/pages/BlockTransactionsPage/index.tsx
+++ b/src/pages/BlockTransactionsPage/index.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../components/Table/components';
 import { trimAddress } from '../../utils/address';
 import { dateDiffRelative, getTextForRelativeTimeDifference } from '../../utils/date';
-import { CoinLinkSkip, TableContainer } from '../AddressPage/components';
+import { CoinLinkSkip, ContractLinkSkip, CopyButtonIcon, HeadlineAddressButton, TableContainer, TableHeadlineAddressButton, Tooltip, TransactionFromAddressWrapper, TxRecipient } from '../AddressPage/components';
 
 import type { BlockTransactionFragment } from './__generated__/operations';
 import { useBlockTransactionsPageQuery } from './__generated__/operations';
@@ -54,6 +54,10 @@ export default function BlockTransactionsPage() {
 }
 
 function Transactions({ transactions }: { transactions: BlockTransactionFragment[] }) {
+  const onClickCopy = (address: string) => {
+    navigator.clipboard.writeText(address);
+  };
+
   return (
     <TableContainer>
       <TableHeadlineContainer>
@@ -100,16 +104,26 @@ function Transactions({ transactions }: { transactions: BlockTransactionFragment
                       switch (input.__typename) {
                         case 'InputCoin': {
                           return (
-                            <TxHashLink key={idx} to={`/address/${input.owner}`}>
-                              {trimAddress(input.owner)}
-                            </TxHashLink>
+                            <TransactionFromAddressWrapper key={idx}>
+                              <TxRecipient  to={`/address/${input.owner}`}>
+                                {trimAddress(input.owner)}
+                              </TxRecipient>
+                              <TableHeadlineAddressButton
+                                onClick={() => {
+                                  onClickCopy(input.owner);
+                                }}
+                              >
+                                <CopyButtonIcon />
+                                <Tooltip>Copy Address</Tooltip>
+                              </TableHeadlineAddressButton>
+                            </TransactionFromAddressWrapper>
                           );
                         }
                         case 'InputContract': {
                           return (
-                            <TxHashLink key={idx} to={`/address/${input.contract.id}`}>
+                            <ContractLinkSkip key={idx} to="">
                               {trimAddress(input.contract.id)}
-                            </TxHashLink>
+                            </ContractLinkSkip>
                           );
                         }
                         default: {

--- a/src/pages/TransactionPage/index.tsx
+++ b/src/pages/TransactionPage/index.tsx
@@ -5,6 +5,7 @@ import { Header } from '../../components/Header';
 import { ExpandIcon, ShrinkIcon } from '../../components/Icons';
 import { trimAddress } from '../../utils';
 import { parseToFormattedNumber } from '../../utils/bigNumber';
+import { CopyButtonIcon, TableHeadlineAddressButton, Tooltip } from '../AddressPage/components';
 import { UTXODetailsValue } from '../CreateTransactionPage/components';
 
 import type { InputFragment, OutputFragment } from './__generated__/operations';
@@ -201,6 +202,10 @@ function UTXOInputBox({
   expanded: boolean;
   idx: number;
 }) {
+  const onClickCopy = (address: string) => {
+    navigator.clipboard.writeText(address);
+  };
+
   switch (input.__typename) {
     case 'InputCoin': {
       return (
@@ -219,9 +224,17 @@ function UTXOInputBox({
             <UTXODetailsContainer>
               <UTXODetailsRow>
                 <UTXODetailsKey>Owner:</UTXODetailsKey>
-                <UTXODetailsLink to={`/address/${input.utxoId}`}>
+                <UTXODetailsLink to={`/address/${input.owner}`}>
                   {trimAddress(input.owner)}
                 </UTXODetailsLink>
+                <TableHeadlineAddressButton
+                  onClick={() => {
+                    onClickCopy(input.owner);
+                  }}
+                >
+                  <CopyButtonIcon />
+                  <Tooltip>Copy Address</Tooltip>
+                </TableHeadlineAddressButton>
               </UTXODetailsRow>
               <UTXODetailsRow>
                 <UTXODetailsKey>Amount:</UTXODetailsKey>
@@ -287,6 +300,10 @@ function UTXOInputBox({
 }
 
 function UTXOOutput({ output }: { output: OutputFragment }) {
+  const onClickCopy = (address: string) => {
+    navigator.clipboard.writeText(address);
+  };
+
   switch (output.__typename) {
     case 'ContractCreated': {
       return (
@@ -320,7 +337,17 @@ function UTXOOutput({ output }: { output: OutputFragment }) {
         <>
           <UTXODetailsRow>
             <UTXODetailsKey>To:</UTXODetailsKey>
-            <UTXOHashOutputSkip to="">{trimAddress(output.to)}</UTXOHashOutputSkip>
+            <UTXODetailsLink to={`/address/${output.to}`}>
+              {trimAddress(output.to)}
+            </UTXODetailsLink>
+            <TableHeadlineAddressButton
+              onClick={() => {
+                onClickCopy(output.to);
+              }}
+            >
+              <CopyButtonIcon />
+              <Tooltip>Copy Address</Tooltip>
+            </TableHeadlineAddressButton>
           </UTXODetailsRow>
           <UTXODetailsRow>
             <UTXODetailsKey>Amount:</UTXODetailsKey>


### PR DESCRIPTION
Added copy button to pages that had addresses cut, following this pattern:
<img width="506" alt="image" src="https://user-images.githubusercontent.com/8636507/168917011-ab7b58cc-f72e-4cc3-8de9-c31b3ee278f9.png">


Closes #66