### PR TITLE
Update default node to SwaySwap

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           CI: false
           PUBLIC_URL: "/${{ github.event.repository.name }}"
-          REACT_APP_GRAPHQL_API_ENDPOINT: "https://dubai.swayswap.io/graphql"
+          REACT_APP_GRAPHQL_API_ENDPOINT: "https://node.swayswap.io/graphql"
         run: |
           npm ci
           npm run build


### PR DESCRIPTION
While waiting for #74, setting default node to SwaySwap's. The Dubai node is retired anyways.