### PR TITLE
Better gas price display.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-export const BASE_COIN_NAME = "Ether";
+export const BASE_COIN_NAME = 'Ether';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const BASE_COIN_NAME = "Ether";

--- a/src/pages/TransactionPage/index.tsx
+++ b/src/pages/TransactionPage/index.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 
 import { Header } from '../../components/Header';
 import { ExpandIcon, ShrinkIcon } from '../../components/Icons';
+import { BASE_COIN_NAME } from '../../constants';
 import { trimAddress } from '../../utils';
 import { parseToFormattedNumber } from '../../utils/bigNumber';
 import { CopyButtonIcon, TableHeadlineAddressButton, Tooltip } from '../AddressPage/components';
@@ -81,7 +82,7 @@ export default function TransactionPage() {
             </TransactionDataRow>
             <TransactionDataRow>
               <RowKeyColumn>Gas Price:</RowKeyColumn>
-              <RowValueColumn>{tx.gasPrice}</RowValueColumn>
+              <RowValueColumn>{parseToFormattedNumber(tx.gasPrice)} {BASE_COIN_NAME}</RowValueColumn>
             </TransactionDataRow>
             <TransactionDataRow>
               <RowKeyColumn>Gas Limit:</RowKeyColumn>

--- a/src/pages/TransactionPage/index.tsx
+++ b/src/pages/TransactionPage/index.tsx
@@ -82,7 +82,9 @@ export default function TransactionPage() {
             </TransactionDataRow>
             <TransactionDataRow>
               <RowKeyColumn>Gas Price:</RowKeyColumn>
-              <RowValueColumn>{parseToFormattedNumber(tx.gasPrice)} {BASE_COIN_NAME}</RowValueColumn>
+              <RowValueColumn>
+                {parseToFormattedNumber(tx.gasPrice)} {BASE_COIN_NAME}
+              </RowValueColumn>
             </TransactionDataRow>
             <TransactionDataRow>
               <RowKeyColumn>Gas Limit:</RowKeyColumn>


### PR DESCRIPTION
- Add base coin name ("Ether" in this case, can extend this later to a per-network configuration).
- Calculate the gas price with decimals. Otherwise, the gas price would be in wei (or in this case, mETH) instead of Ether.

Note: this change accounts for decimals, but not gas price factor. That will be handled in a follow-up PR.