### PR TITLE
Set default gas price factor to 1.

### DIFF
--- a/src/pages/TransactionPage/index.tsx
+++ b/src/pages/TransactionPage/index.tsx
@@ -60,11 +60,12 @@ export default function TransactionPage() {
   if (!tx) return null;
 
   const lastReceipt = tx.receipts?.[tx.receipts.length - 1];
+  const gasPriceFactor = +(chains[0].consensusParameters?.gasPriceFactor || 1)
   const transactionFee = calculateTransactionFee({
     bytePrice: +tx.bytePrice,
     rawPayload: tx.rawPayload,
     witnesses: tx.witnesses,
-    gasPriceFactor: +(chains[0].consensusParameters?.gasPriceFactor || 0),
+    gasPriceFactor,
     gasPrice: +tx.gasPrice,
     gasUsed: +(lastReceipt?.gasUsed || 0),
   });


### PR DESCRIPTION
If for whatever reason we can't find a gas price factor, set it to 1 instead of 0 so as not to divide by zero.