### PR TITLE
feat: enable search by bech32 address

### DIFF
--- a/src/pages/AddressPage/index.tsx
+++ b/src/pages/AddressPage/index.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom';
 
 import { Header } from '../../components/Header';
 import { QRModal } from '../../components/Modals/QRModal';
+import { getB56Address } from '../../utils/address';
 
 import BalancesTable from './BalancesTable';
 import TransactionsTable from './TransactionsTable';
@@ -24,7 +25,8 @@ import {
 } from './components';
 
 export default function AddressPage() {
-  const { address } = useParams() as any;
+  const params = useParams() as any;
+  const address = getB56Address(params.address);
   const [copyTooltip] = useState('Copy address');
   const [modal, setModal] = useState(false);
   const { loading, data } = useAddressPageQuery({
@@ -69,7 +71,10 @@ export default function AddressPage() {
               <HeadlineAddressContainer>
                 <HeadlineAddressHeader>
                   {`Address:  `}
-                  <HeadlineAddress>{address}</HeadlineAddress>
+                  <div>
+                    <HeadlineAddress>{toBech32(address)}</HeadlineAddress>
+                    <HeadlineAddress>{address}</HeadlineAddress>
+                  </div>
                 </HeadlineAddressHeader>
               </HeadlineAddressContainer>
             </HeadlineContainer>

--- a/src/pages/HomePage/components.tsx
+++ b/src/pages/HomePage/components.tsx
@@ -59,8 +59,15 @@ export const SearchIcon = styled(SearchSvg)<{ isDisabled?: boolean }>`
 
 export const SearchNotFound = styled.div`
   position: absolute;
-  left: 14px;
+  left: 0px;
   top: 50px;
+`;
+
+export const SearchNotValid = styled.div`
+  position: absolute;
+  left: 0px;
+  top: 50px;
+  color: #f54747;
 `;
 
 export const DataContainer = styled.div`

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import type { PageInfo } from '../../api/__generated__/types';
 import { Header } from '../../components/Header';
-import { getB56Address, getValidTransactionId } from '../../utils/address';
+import { getB56Address, getValidTransactionId, isValidAddress } from '../../utils/address';
 
 import { RecentBlocks } from './RecentBlocks';
 import { RecentTransactions } from './RecentTransactions';
@@ -21,6 +21,7 @@ import {
   InputContainer,
   SearchIcon,
   SearchNotFound,
+  SearchNotValid,
 } from './components';
 
 const PAGE_LIMIT = 5;
@@ -32,6 +33,7 @@ export default function HomePage() {
   const [currentPage, setCurrentPage] = useState(1);
   const [searchText, setSearchText] = useState<string>('');
   const [isSearchNotFound, setIsSearchNotFound] = useState(false);
+  const timerRef = useRef<number | undefined>();
   const transactionsQuery = useHomePageTransactionsQuery({
     variables: { last: PAGE_LIMIT },
   });
@@ -42,7 +44,19 @@ export default function HomePage() {
   });
   const navigate = useNavigate();
 
-  const isAllowedToSearch = [66, 63].includes(searchText.length);
+  const searchState = useMemo<{
+    isValid: boolean;
+    empty: boolean;
+  }>(
+    () => ({
+      // Mark search as valid, when the text inputted has the length;
+      // 66 witch indicates a valid hex address or txId
+      // or if this is a valid bech32 address
+      isValid: searchText.length === 66 || isValidAddress(searchText),
+      empty: searchText.length === 0,
+    }),
+    [searchText]
+  );
 
   useEffect(() => {
     if (blocksQuery.loading) return;
@@ -60,6 +74,14 @@ export default function HomePage() {
     setTransactions(transactions);
     setPageInfo(transactionsQuery.data?.transactions?.pageInfo);
   }, [transactionsQuery.loading, transactionsQuery.data, transactionsQuery.error]);
+
+  useEffect(
+    () => () => {
+      // Clear timeout when component is unmounted
+      clearTimeout(timerRef.current);
+    },
+    []
+  );
 
   const handleNextPage = () => {
     transactionsQuery.refetch({
@@ -81,8 +103,16 @@ export default function HomePage() {
     setCurrentPage(currentPage - 1);
   };
 
+  const showNotFound = (show: boolean) => {
+    clearTimeout(timerRef.current);
+    setIsSearchNotFound(show);
+    if (show) {
+      timerRef.current = setTimeout(() => setIsSearchNotFound(false), 5000) as any;
+    }
+  };
+
   const handleClickSearch = async () => {
-    if (isAllowedToSearch && searchText) {
+    if (searchState.isValid && !searchState.empty) {
       const result = await searchQuery.refetch({
         transaction: getValidTransactionId(searchText),
         address: getB56Address(searchText),
@@ -93,8 +123,7 @@ export default function HomePage() {
       } else if (result.data?.transactionsByOwner?.edges?.length) {
         navigate(`/address/${searchText}`);
       } else {
-        setIsSearchNotFound(true);
-        setTimeout(() => setIsSearchNotFound(false), 1500);
+        showNotFound(true);
       }
     }
   };
@@ -106,6 +135,11 @@ export default function HomePage() {
     }
   };
 
+  const handleInputSearchText = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchText(e?.target?.value);
+    setIsSearchNotFound(false);
+  };
+
   return (
     <>
       <Header />
@@ -114,14 +148,17 @@ export default function HomePage() {
           <InputContainer>
             <Input
               placeholder="Search for transaction / address"
-              onChange={(e) => setSearchText(e?.target?.value)}
+              onChange={handleInputSearchText}
               onKeyPress={handleSearchKeyPress}
             />
             <SearchIcon
-              isDisabled={!isAllowedToSearch}
-              onClick={isAllowedToSearch ? handleClickSearch : undefined}
+              isDisabled={!searchState.isValid}
+              onClick={searchState.isValid ? handleClickSearch : undefined}
             />
             {isSearchNotFound && <SearchNotFound>Not Found</SearchNotFound>}
+            {!searchState.isValid && !searchState.empty && (
+              <SearchNotValid>Text is not a valid TransactionId or Address</SearchNotValid>
+            )}
           </InputContainer>
           <DataContainer>
             <RecentBlocks blocks={blocks} />

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import type { PageInfo } from '../../api/__generated__/types';
 import { Header } from '../../components/Header';
+import { getB56Address, getValidTransactionId } from '../../utils/address';
 
 import { RecentBlocks } from './RecentBlocks';
 import { RecentTransactions } from './RecentTransactions';
@@ -41,7 +42,7 @@ export default function HomePage() {
   });
   const navigate = useNavigate();
 
-  const isAllowedToSearch = searchText.length === 66;
+  const isAllowedToSearch = [66, 63].includes(searchText.length);
 
   useEffect(() => {
     if (blocksQuery.loading) return;
@@ -83,8 +84,8 @@ export default function HomePage() {
   const handleClickSearch = async () => {
     if (isAllowedToSearch && searchText) {
       const result = await searchQuery.refetch({
-        transaction: searchText,
-        address: searchText,
+        transaction: getValidTransactionId(searchText),
+        address: getB56Address(searchText),
       });
 
       if (result.data?.transaction?.id) {

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,3 +1,5 @@
+import { Address } from 'fuels';
+
 export const trimAddress = (address: string) => {
   if (!address) {
     return '';
@@ -5,3 +7,13 @@ export const trimAddress = (address: string) => {
 
   return `${address.slice(0, 6)}...${address.slice(-6, address.length - 1)}`;
 };
+
+export const getB56Address = (address: string) => {
+  try {
+    return Address.fromString(address).toB256();
+  } catch (e) {
+    return address;
+  }
+};
+
+export const getValidTransactionId = (txId: string) => (txId.startsWith('0x') ? txId : '0x');

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -8,6 +8,14 @@ export const trimAddress = (address: string) => {
   return `${address.slice(0, 6)}...${address.slice(-6, address.length - 1)}`;
 };
 
+export const isValidAddress = (address: string) => {
+  try {
+    return !!Address.fromString(address).toB256();
+  } catch (e) {
+    return false;
+  }
+};
+
 export const getB56Address = (address: string) => {
   try {
     return Address.fromString(address).toB256();


### PR DESCRIPTION
- Enable search for bech32 addresses on the search bar
- Enable linking using bech32 address ex.: [/address/fuel129wju39hs7ju0u4sm9enu9srvrv0af0m0epufej925e48gkrtjus9q9syg](https://fuellabs.github.io/block-explorer-v2/address/fuel129wju39hs7ju0u4sm9enu9srvrv0af0m0epufej925e48gkrtjus9q9syg?providerUrl=https%3A%2F%2Fnode-beta-1.fuel.network%2Fgraphql)
- Add feedback when the text input on the search box is not valid
   <img width="747" alt="Screen Shot 2022-09-04 at 5 13 52 PM" src="https://user-images.githubusercontent.com/3941923/188331787-76a93051-2a3e-44ba-bbca-2d77c8d1f7eb.png">
