### PR TITLE
feat(StandardSurface): adds contrast to foreground elements and background

### DIFF
--- a/src/components/Surface/components.tsx
+++ b/src/components/Surface/components.tsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const StandardSurface = styled.div`
+  background-color: #081c17;
+`;

--- a/src/components/Table/components.tsx
+++ b/src/components/Table/components.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 
-export const TableContainer = styled.div`
+import { StandardSurface } from '../Surface/components';
+
+export const TableContainer = styled(StandardSurface)`
   padding: 8px;
   box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.2);
   border: solid 1px #808080;

--- a/src/index.css
+++ b/src/index.css
@@ -12,7 +12,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
-  background-color: #081c17;
+  background-color: #051310;
   color: #f8fefc;
 }
 

--- a/src/pages/AddressPage/components.tsx
+++ b/src/pages/AddressPage/components.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { ButtonReset } from '../../components/Button/components';
 import { CopyIcon, PlusIcon, QRIcon, ArrowIcon } from '../../components/Icons';
+import { StandardSurface } from '../../components/Surface/components';
 import { UTXOHashOutputSkip } from '../TransactionPage/components';
 
 export const Container = styled.section``;
@@ -227,7 +228,7 @@ export const TokenDropdownIcon = styled(ArrowIcon)`
   height: 12px !important;
 `;
 
-export const TableContainer = styled.div`
+export const TableContainer = styled(StandardSurface)`
   padding: 8px;
   box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.2);
   border: solid 1px #808080;

--- a/src/pages/BlockPage/components.tsx
+++ b/src/pages/BlockPage/components.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { ArrowIcon } from '../../components/Icons';
+import { StandardSurface } from '../../components/Surface/components';
 
 export const Container = styled.section``;
 
@@ -30,7 +31,7 @@ export const Title = styled.h2`
   }
 `;
 
-export const BlockDataContainer = styled.div`
+export const BlockDataContainer = styled(StandardSurface)`
   padding: 16px 32px;
   box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
   border: solid 0.5px #808080;

--- a/src/pages/CoinPage/components.tsx
+++ b/src/pages/CoinPage/components.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { ButtonReset } from '../../components/Button/components';
 import { LogoIcon } from '../../components/Icons';
+import { StandardSurface } from '../../components/Surface/components';
 
 export const Container = styled.section``;
 
@@ -55,7 +56,7 @@ export const CoinName = styled.span`
 
 export const CoinIcon = styled(LogoIcon)``;
 
-export const CoinDetailsContainer = styled.div`
+export const CoinDetailsContainer = styled(StandardSurface)`
   margin: 0 0 40px;
   padding: 20px 24px;
   border: solid 1px #808080;

--- a/src/pages/ContractPage/components.tsx
+++ b/src/pages/ContractPage/components.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { ButtonReset } from '../../components/Button/components';
 import { LogoIcon } from '../../components/Icons';
+import { StandardSurface } from '../../components/Surface/components';
 
 export const Container = styled.section``;
 
@@ -55,7 +56,7 @@ export const CoinName = styled.span`
 
 export const CoinIcon = styled(LogoIcon)``;
 
-export const CoinDetailsContainer = styled.div`
+export const CoinDetailsContainer = styled(StandardSurface)`
   margin: 0 0 40px;
   padding: 20px 24px;
   border: solid 1px #808080;

--- a/src/pages/CreateTransactionPage/components.tsx
+++ b/src/pages/CreateTransactionPage/components.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { ButtonReset } from '../../components/Button/components';
 import { ArrowIcon, FileIcon } from '../../components/Icons';
+import { StandardSurface } from '../../components/Surface/components';
 
 export const Container = styled.section``;
 
@@ -222,7 +223,7 @@ export const UTXOSeparatorColumn = styled.div`
     margin: 4px auto 24px;
   }
 `;
-export const UTXOBoxContainer = styled.div`
+export const UTXOBoxContainer = styled(StandardSurface)`
   margin: 0 0 24px;
   border: solid 3px #03261e;
 `;

--- a/src/pages/CreateTransactionPage/components.tsx
+++ b/src/pages/CreateTransactionPage/components.tsx
@@ -55,7 +55,7 @@ export const TitleTransaction = styled.span`
   }
 `;
 
-export const TransactionDataContainer = styled.div`
+export const TransactionDataContainer = styled(StandardSurface)`
   margin: 0 0 36px;
   padding: 16px 32px;
   box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);

--- a/src/pages/HomePage/components.tsx
+++ b/src/pages/HomePage/components.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { ButtonReset } from '../../components/Button/components';
 import { ArrowIcon, SearchIcon as SearchSvg } from '../../components/Icons';
 import { InputReset } from '../../components/Input/components';
+import { StandardSurface } from '../../components/Surface/components';
 
 export const Container = styled.section``;
 
@@ -186,7 +187,7 @@ export const IconButtonRight = styled(IconButton)`
   }
 `;
 
-export const DataBox = styled.div`
+export const DataBox = styled(StandardSurface)`
   border-radius: 12px;
   border: solid 1px #808080;
 `;

--- a/src/pages/TransactionPage/components.tsx
+++ b/src/pages/TransactionPage/components.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { ButtonReset } from '../../components/Button/components';
 import { ArrowIcon } from '../../components/Icons';
+import { StandardSurface } from '../../components/Surface/components';
 
 export const Container = styled.section``;
 
@@ -54,7 +55,7 @@ export const TitleTransaction = styled.span`
   }
 `;
 
-export const TransactionDataContainer = styled.div`
+export const TransactionDataContainer = styled(StandardSurface)`
   margin: 0 0 36px;
   padding: 16px 32px;
   box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
@@ -181,7 +182,7 @@ export const UTXOSeparatorColumn = styled.div`
     margin: 4px auto 24px;
   }
 `;
-export const UTXOBoxContainer = styled.div`
+export const UTXOBoxContainer = styled(StandardSurface)`
   margin: 0 0 24px;
   border: solid 3px #03261e;
 `;
@@ -321,7 +322,7 @@ export const ScriptTitle = styled.span`
   color: #f8fefc;
 `;
 
-export const ScriptContainer = styled.div`
+export const ScriptContainer = styled(StandardSurface)`
   margin: 0 0 36px;
   max-width: 442px;
   border: solid 1px #1e2e2b;


### PR DESCRIPTION
- Increases contrast between background and data
- Adds a `StandardSurface` styled component and applies it to relevant data containers

All changes are shown below (CoinPage code also modified to use the StandardSurface but looks like CoinPage is a work in progress and doesn't actually render on the frontend currently, therefore excluded from images below).

------

Home Page:

<img width="3456" alt="HomePage" src="https://user-images.githubusercontent.com/14224459/197183014-3c01bcb5-405f-4a65-997c-0415bad61d2f.png">

------

Block Page: 

<img width="3456" alt="BlockPage" src="https://user-images.githubusercontent.com/14224459/197183370-c96acd57-16d0-42cc-89a3-a44a216ec548.png">

------

Contract Page:

<img width="3456" alt="ContractPage" src="https://user-images.githubusercontent.com/14224459/197183092-1cbacb1e-b405-4205-9994-fcfd77391888.png">

------

Address Page:

<img width="3456" alt="AddressPage" src="https://user-images.githubusercontent.com/14224459/197183439-40e31ddf-61d2-4d55-94b4-4ea7f2906481.png">

------

Transaction Page:

<img width="3456" alt="TransactionPage" src="https://user-images.githubusercontent.com/14224459/197183496-ec44c8d1-0332-4b23-8ba4-800fec1ec465.png">

------

Create Transaction Page:

<img width="3456" alt="CreateTransactionPage" src="https://user-images.githubusercontent.com/14224459/197183643-a43135f1-e1c5-4b7e-a9ac-9df7a9b6ca3c.png">

------

Transaction List Page:

<img width="3456" alt="TransactionListPage" src="https://user-images.githubusercontent.com/14224459/197183539-b7c71b44-9352-4210-ba64-909a3d4d0832.png">